### PR TITLE
build: update poe format command.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ shell = "pytest tests --color=yes"
 [[tool.poe.tasks.format]]
 help = "Formats code"
 shell = """
+    ruff --select I --fix .
     ruff format .
     """
 


### PR DESCRIPTION
Currently ruff format does not sort imports
(see https://github.com/astral-sh/ruff/issues/8926). This means that executing poe format was not sorting them which can cause errors during linting check in the pipeline.