### PR TITLE
fix: usage of enum with Python 3.12

### DIFF
--- a/src/zxbc/zxbparser.py
+++ b/src/zxbc/zxbparser.py
@@ -3567,7 +3567,7 @@ def p_error(p):
         if loop_info.type == LoopType.FOR:
             errmsg.syntax_error_for_without_next(loop_info.lineno)
         else:
-            errmsg.syntax_error_loop_not_closed(loop_info.lineno, loop_info.type)
+            errmsg.syntax_error_loop_not_closed(loop_info.lineno, loop_info.type.value)
     # If there were previous errors, stop here
     # since this end of file is due to previous errors
     if gl.has_errors:


### PR DESCRIPTION
In 3.12 this should be an StrEnum (not available in Python 3.10). Use the value instead.