### PR TITLE
feat: increase test timeout

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -579,20 +579,6 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
-name = "pytest-timeout"
-version = "1.4.2"
-description = "py.test plugin to abort hanging tests"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytest-timeout-1.4.2.tar.gz", hash = "sha256:20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76"},
-    {file = "pytest_timeout-1.4.2-py2.py3-none-any.whl", hash = "sha256:541d7aa19b9a6b4e475c759fd6073ef43d7cdc9a92d95644c260076eb257a063"},
-]
-
-[package.dependencies]
-pytest = ">=3.6.0"
-
-[[package]]
 name = "pytest-xdist"
 version = "3.6.1"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
@@ -842,4 +828,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d420834606f68e6a401e5c93782aa4821a81bb3b29dc6398c8ccfb0340b04802"
+content-hash = "1b774799c972c657ada273938c2cc2cb5f1621f6d908274c97232787e59e5d86"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ python = "^3.10"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
-pytest-timeout = "^1.3.4"
 bump2version = "^1.0.0"
 pre-commit = "^2.15.0"
 mkdocs = "^1.2.2"
@@ -72,7 +71,7 @@ shell = """
 [tool.pytest.ini_options]
 minversion = "6.0"
 norecursedirs = ["test_*tmp", "runtime"]
-addopts = "--cov=. --cov-report term-missing -n auto --dist=loadgroup --color=yes"
+addopts = "--cov=. -n auto --dist=loadgroup --color=yes --doctest-glob=.DISABLED"
 
 [tool.mypy]
 check_untyped_defs = true

--- a/tests/functional/test_.py
+++ b/tests/functional/test_.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 # vim:ts=4:et:ai
 
+import doctest
+import glob
 import os
 import sys
 import tempfile
 from io import StringIO
+from typing import Final
 
+import pytest
 import test
 
 from src.api.utils import chdir
+
+FILE_PATH: Final[str] = os.path.realpath(os.path.dirname(__file__) or os.curdir)
 
 
 class OutputProxy(StringIO):
@@ -29,6 +35,8 @@ def process_file(fname: str, params=None):
         if fname.lower().endswith(".bas"):
             params.append("-O --hide-warning-codes")
 
+    params.extend(["--timeout", "60", "-E"])
+
     try:
         with tempfile.TemporaryDirectory() as tmp_dirname:
             if os.path.dirname(fname).startswith("/"):
@@ -44,3 +52,11 @@ def process_file(fname: str, params=None):
 
     finally:
         test.TEMP_DIR = None
+
+
+@pytest.mark.parametrize("fname", glob.glob(os.path.join("cmdline", "*.txt"), root_dir=FILE_PATH))
+def test_errmsg(fname: str):
+    with chdir(FILE_PATH):
+        result = doctest.testfile(fname)  # evaluates to True on failure
+
+    assert not result.failed


### PR DESCRIPTION
Also remove pytest-timeout since we're use our own timeout solution for test.

When using pytest-xdist the test time might fluctuate due to excessive parallelization and coverage meausre.