### PR TITLE
refact: remove test_errmsg method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ shell = """
 [tool.pytest.ini_options]
 minversion = "6.0"
 norecursedirs = ["test_*tmp", "runtime"]
-addopts = "--cov=. -n auto --dist=loadgroup --color=yes --doctest-glob=.DISABLED"
+addopts = "--cov=. -n auto --dist=loadgroup --color=yes"
 
 [tool.mypy]
 check_untyped_defs = true

--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -9,7 +9,7 @@ diffbas:
 test: prepro bin asm bas
 
 test_:
-	pytest . -n0 -k "cmdline"
+	pytest . -n auto --no-cov -k "cmdline"
 
 prepro:
 	./test.py zxbpp/*.bi

--- a/tests/functional/cmdline/test_errmsg.txt
+++ b/tests/functional/cmdline/test_errmsg.txt
@@ -1,19 +1,5 @@
 >>> from test_ import process_file
 
->>> process_file('arch/zx48k/doloop1.bas')
-doloop1.bas:2: warning: Infinite empty loop
->>> process_file('arch/zx48k/dountil1.bas')
-dountil1.bas:2: warning: Condition is always False
-dountil1.bas:2: warning: Empty loop
->>> process_file('arch/zx48k/doloop2.bas')
-doloop2.bas:4: warning: Using default implicit type 'ubyte' for 'a'
-doloop2.bas:5: warning: Condition is always True
-doloop2.bas:8: warning: Condition is always True
-doloop2.bas:12: warning: Condition is always False
-doloop2.bas:4: warning: Variable 'a' is never used
->>> process_file('arch/zx48k/dowhile1.bas')
-dowhile1.bas:1: warning: Condition is always True
-dowhile1.bas:1: warning: Empty loop
 >>> process_file('arch/zx48k/subcall1.bas')
 subcall1.bas:6: error: 'test' is a SUB not a FUNCTION
 >>> process_file('arch/zx48k/subcall2.bas')
@@ -56,16 +42,6 @@ strict.bas:2: warning: Using default implicit type 'float' for 'b'
 strict.bas:4: error: strict mode: missing type declaration for 'a'
 >>> process_file('arch/zx48k/errletfunc.bas')
 errletfunc.bas:5: error: Cannot assign a value to 'x'. It's not a variable
->>> process_file('arch/zx48k/read0.bas')
-read0.bas:12: error: 'x' is a SUB not a FUNCTION
->>> process_file('arch/zx48k/read1.bas')
-read1.bas:11: error: Cannot read 'x'. It's an array
->>> process_file('arch/zx48k/read3.bas')
-read3.bas:9: error: 'x' is neither an array nor a function.
->>> process_file('arch/zx48k/read6.bas')
-read6.bas:12: error: Syntax error. Can only read a variable or an array element
->>> process_file('arch/zx48k/data0.bas')
-data0.bas:2: error: 'b' is neither an array nor a function.
 >>> process_file('arch/zx48k/ifempty4.bas')
 ifempty4.bas:3: warning: Useless empty IF ignored
 >>> process_file('arch/zx48k/ifempty1.bas')

--- a/tests/functional/cmdline/test_loop_check.txt
+++ b/tests/functional/cmdline/test_loop_check.txt
@@ -1,0 +1,16 @@
+>>> from test_ import process_file
+
+>>> process_file('arch/zx48k/doloop1.bas')
+doloop1.bas:2: warning: Infinite empty loop
+>>> process_file('arch/zx48k/dountil1.bas')
+dountil1.bas:2: warning: Condition is always False
+dountil1.bas:2: warning: Empty loop
+>>> process_file('arch/zx48k/doloop2.bas')
+doloop2.bas:4: warning: Using default implicit type 'ubyte' for 'a'
+doloop2.bas:5: warning: Condition is always True
+doloop2.bas:8: warning: Condition is always True
+doloop2.bas:12: warning: Condition is always False
+doloop2.bas:4: warning: Variable 'a' is never used
+>>> process_file('arch/zx48k/dowhile1.bas')
+dowhile1.bas:1: warning: Condition is always True
+dowhile1.bas:1: warning: Empty loop

--- a/tests/functional/cmdline/test_read_data.txt
+++ b/tests/functional/cmdline/test_read_data.txt
@@ -1,0 +1,12 @@
+>>> from test_ import process_file
+
+>>> process_file('arch/zx48k/read0.bas')
+read0.bas:12: error: 'x' is a SUB not a FUNCTION
+>>> process_file('arch/zx48k/read1.bas')
+read1.bas:11: error: Cannot read 'x'. It's an array
+>>> process_file('arch/zx48k/read3.bas')
+read3.bas:9: error: 'x' is neither an array nor a function.
+>>> process_file('arch/zx48k/read6.bas')
+read6.bas:12: error: Syntax error. Can only read a variable or an array element
+>>> process_file('arch/zx48k/data0.bas')
+data0.bas:2: error: 'b' is neither an array nor a function.

--- a/tests/functional/test_.py
+++ b/tests/functional/test_.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python3
 # vim:ts=4:et:ai
 
-import doctest
-import glob
 import os
 import sys
 import tempfile
 from io import StringIO
 from typing import Final
 
-import pytest
 import test
 
 from src.api.utils import chdir
@@ -52,11 +49,3 @@ def process_file(fname: str, params=None):
 
     finally:
         test.TEMP_DIR = None
-
-
-@pytest.mark.parametrize("fname", glob.glob(os.path.join("cmdline", "*.txt"), root_dir=FILE_PATH))
-def test_errmsg(fname: str):
-    with chdir(FILE_PATH):
-        result = doctest.testfile(fname)  # evaluates to True on failure
-
-    assert not result.failed

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -14,7 +14,6 @@ TEST_PATH = os.path.dirname(os.path.realpath(__file__))
     "fname",
     reversed([os.path.join(TEST_PATH, f) for f in glob.glob(os.path.join(TEST_PATH, "**", "*.bas"), recursive=True)]),
 )
-@pytest.mark.timeout(15)
 @pytest.mark.xdist_group(name="test_basic")
 def test_basic(fname):
     test.main(["-d", fname])


### PR DESCRIPTION
Not needed anymore. Pytest will execute .txt files as doctest directly in a parallel way.