### PR TITLE
test: fix runtime test

### DIFF
--- a/tests/runtime/cases/point.bas
+++ b/tests/runtime/cases/point.bas
@@ -1,9 +1,7 @@
+' PARAMS: -D SCREEN_X_OFFSET=127 -D SCREEN_Y_OFFSET=96
 #include "lib/tst_framework.bas"
 
 INIT("Testing SCREEN X,Y coords shift")
-
-#define SCREEN_Y_OFFSET 96
-#define SCREEN_X_OFFSET 127
 
 #include <point.bas>
 

--- a/tests/runtime/cases/screen_xy_shift.bas
+++ b/tests/runtime/cases/screen_xy_shift.bas
@@ -1,9 +1,8 @@
+' PARAMS: -D SCREEN_Y_OFFSET=96 -D SCREEN_X_OFFSET=127
+
 #include "lib/tst_framework.bas"
 
 INIT("Testing SCREEN X,Y coords shift")
-
-#define SCREEN_Y_OFFSET 96
-#define SCREEN_X_OFFSET 127
 
 PLOT 0, 0
 DRAW 10, 10

--- a/tests/runtime/check_test.py
+++ b/tests/runtime/check_test.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 
+import signal
 import sys
 
 import zx
+
+
+def signal_handler(sig, frame):
+    print("Killed!")
+    sys.exit(1)
 
 
 class Stop(Exception):
@@ -33,7 +39,7 @@ class Tester(zx.Emulator):
             pass
 
         # Get view to the video memory.
-        screen = self.get_memory_view(0x4000, 6 * 1024 + 768)
+        screen = self.read(0x4000, 6 * 1024 + 768)
 
         # Compare it with the etalon screenshot.
         with open(ram_filename, "rb") as f:
@@ -43,6 +49,7 @@ class Tester(zx.Emulator):
 
 
 def main():
+    signal.signal(signal.SIGTERM, signal_handler)
     with Tester() as t:
         t.run_test(sys.argv[1], sys.argv[2])
     print("OK")

--- a/tests/runtime/run
+++ b/tests/runtime/run
@@ -4,5 +4,5 @@
 RUN=$(basename -s .bas $1)
 rm -f "$RUN.tzx"
 killall fuse 2>/dev/null
-../../zxbc.py -TaB $1 --debug-memory || exit 1
+../../zxbc.py -TaB "$@" --debug-memory || exit 1
 fuse --auto-load --speed=19000 --machine=plus2 "$RUN.tzx" &

--- a/tests/runtime/test_all
+++ b/tests/runtime/test_all
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-#for i in cases/*.bas; do ./test_case $i; done
-
+# run tests in parallel, one per CPU
 parallel ./test_case ::: cases/*.bas
-

--- a/tests/runtime/test_case
+++ b/tests/runtime/test_case
@@ -4,13 +4,13 @@
 # Test a single case (prog.bas file)
 # A RAM dump /expected/prog.tzx.scr must exists
 
-TIMEOUT=120
+TIMEOUT=180
 TIMEKILL=$((TIMEOUT+30))
 
 echo -n "Testing $(basename $1): "
 RUN=$(basename -s .bas $1).tzx
-rm -f "$RUN"
-../../zxbc.py -TaB $1 --debug-memory 2>/dev/null
+rm -f "$RUN" 2>/dev/null
+../../zxbc.py -TaB $1 $(grep "PARAMS:" $1 |cut -d':' -f2-) --debug-memory 2>/dev/null
 timeout -k $TIMEKILL $TIMEOUT ./check_test.py "$RUN" "./expected/${RUN}.scr"
 RETVAL=$?
 rm -f "$RUN" 2>/dev/null


### PR DESCRIPTION
Now if there's a line with a comment like
'PARAM: xxxx
the xxx will be pass as parameter to the compiler.

The timeout has been increased to 180secs (3 mins.)