### PR TITLE
refact: change --format=IR to --format=ir

### DIFF
--- a/src/zxbc/args_parser.py
+++ b/src/zxbc/args_parser.py
@@ -13,7 +13,7 @@ from .version import VERSION
 class FileType(StrEnum):
     ASM = "asm"
     BIN = "bin"
-    IR = "IR"
+    IR = "ir"
     SNA = "sna"
     TAP = "tap"
     TZX = "tzx"
@@ -59,25 +59,25 @@ def parser() -> argparse.ArgumentParser:
         "-T",
         "--tzx",
         action="store_true",
-        help="Sets output format to .tzx (default is .bin). DEPRECATED.",
+        help="Sets output format to .tzx (default is .bin). DEPRECATED. Use -f",
     )
     output_file_type_group.add_argument(
         "-t",
         "--tap",
         action="store_true",
-        help="Sets output format to .tap (default is .bin). DEPRECATED.",
+        help="Sets output format to .tap (default is .bin). DEPRECATED. Use -f",
     )
     output_file_type_group.add_argument(
         "-A",
         "--asm",
         action="store_true",
-        help="Sets output format to .asm. DEPRECATED",
+        help="Sets output format to .asm. DEPRECATED. Use -f",
     )
     parser_.add_argument(
         "-E",
         "--emit-backend",
         action="store_true",
-        help="Emits backend code (IR) instead of ASM or binary. DEPRECATED.",
+        help="Emits backend code (IR) instead of ASM or binary. DEPRECATED. Use -f",
     )
     output_file_type_group.add_argument(
         "--parse-only", action="store_true", help="Only parses to check for syntax and semantic errors"

--- a/tests/functional/cmdline/test_cmdline.txt
+++ b/tests/functional/cmdline/test_cmdline.txt
@@ -4,7 +4,7 @@
 
 >>> process_file('arch/zx48k/arrbase1.bas', ['-q', '-S', '-O --mmap arrbase1.map'])
 usage: zxbc.py [-h] [-d] [-O OPTIMIZE] [-o OUTPUT_FILE] [-T] [-t] [-A] [-E]
-               [--parse-only] [-f {asm,bin,IR,sna,tap,tzx,z80}] [-B] [-a]
+               [--parse-only] [-f {asm,bin,ir,sna,tap,tzx,z80}] [-B] [-a]
                [-S ORG] [-e STDERR] [--array-base ARRAY_BASE]
                [--string-base STRING_BASE] [-Z] [-H HEAP_SIZE]
                [--heap-address HEAP_ADDRESS] [--debug-memory] [--debug-array]


### PR DESCRIPTION
IR stands for Intermediate Representation.
This format is used by ZXBasicStudio and is useful for inspection.

Also, the extension is now .ir instead of IR.
Some options helps have also been updated.