### PR TITLE
fix: do not emit spurious warning with --enable-break

### DIFF
--- a/src/api/optimize.py
+++ b/src/api/optimize.py
@@ -91,7 +91,7 @@ class UnreachableCodeVisitor(UniqueVisitor):
         if (
             node.class_ == CLASS.function
             and node.body.token == "BLOCK"
-            and (not node.body or node.body[-1].token != "RETURN")
+            and (not node.body or node.body[-1].token not in ("CHKBREAK", "RETURN"))
         ):
             # String functions must *ALWAYS* return a value.
             # Put a sentinel ("dummy") return "" sentence that will be removed if other is detected
@@ -109,7 +109,7 @@ class UnreachableCodeVisitor(UniqueVisitor):
         i = 0
         while i < len(node) - 1:
             child = node[i]
-            if child.token == "LABEL" and node[i + 1].token == "CHKBREAK":
+            if child.token in ("LABEL", "RETURN") and node[i + 1].token == "CHKBREAK":
                 node.pop(i + 1)
                 continue
             i += 1

--- a/tests/functional/arch/zx48k/warn_brk.asm
+++ b/tests/functional/arch/zx48k/warn_brk.asm
@@ -1,0 +1,53 @@
+	org 32768
+.core.__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (.core.__CALL_BACK__), hl
+	ei
+	jp .core.__MAIN_PROGRAM__
+.core.__CALL_BACK__:
+	DEFW 0
+.core.ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+.core.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_END - .core.ZXBASIC_USER_DATA
+	.core.__LABEL__.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_LEN
+	.core.__LABEL__.ZXBASIC_USER_DATA EQU .core.ZXBASIC_USER_DATA
+.core.ZXBASIC_USER_DATA_END:
+.core.__MAIN_PROGRAM__:
+	call _distance
+	ld (0), a
+	ld hl, 0
+	ld b, h
+	ld c, l
+.core.__END_PROGRAM:
+	di
+	ld hl, (.core.__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	exx
+	pop iy
+	pop ix
+	ei
+	ret
+_distance:
+	push ix
+	ld ix, 0
+	add ix, sp
+	ld hl, 0
+	push hl
+	ld l, (ix-2)
+	ld h, (ix-1)
+	ld a, l
+_distance__leave:
+	ld sp, ix
+	pop ix
+	ret
+	;; --- end of user code ---
+	END

--- a/tests/functional/arch/zx48k/warn_brk.bas
+++ b/tests/functional/arch/zx48k/warn_brk.bas
@@ -1,0 +1,7 @@
+FUNCTION distance () as uByte
+    DIM c as integer
+    return CAST(uByte,c)
+END FUNCTION
+
+POKE 0, distance()
+

--- a/tests/functional/cmdline/test_warning.txt
+++ b/tests/functional/cmdline/test_warning.txt
@@ -8,3 +8,5 @@ mcleod3.bas:3: error: 'GenerateSpaces' is neither an array nor a function.
 >>> process_file('arch/zx48k/doloop2.bas', ['-S', '-q', '-O -W110'])
 doloop2.bas:4: warning: [W100] Using default implicit type 'ubyte' for 'a'
 doloop2.bas:4: warning: [W150] Variable 'a' is never used
+
+>>> process_file('arch/zx48k/warn_brk.bas', ['-S', '-q', '-O --enable-break'])


### PR DESCRIPTION
When using --enable break, RETURN within functions cause an Unreachable Code warning (the code after the RETURN was the BREAK check). Fixed.

Fixes #822 