### PR TITLE
fix: do not emit spurious warning

### DIFF
--- a/src/api/optimize.py
+++ b/src/api/optimize.py
@@ -91,7 +91,7 @@ class UnreachableCodeVisitor(UniqueVisitor):
         if (
             node.class_ == CLASS.function
             and node.body.token == "BLOCK"
-            and (not node.body or node.body[-1].token not in ("CHKBREAK", "RETURN"))
+            and (not node.body or node.body[-1].token not in {"CHKBREAK", "LABEL", "RETURN"})
         ):
             # String functions must *ALWAYS* return a value.
             # Put a sentinel ("dummy") return "" sentence that will be removed if other is detected

--- a/tests/functional/arch/zx48k/warn_lbl.asm
+++ b/tests/functional/arch/zx48k/warn_lbl.asm
@@ -1,0 +1,50 @@
+	org 32768
+.core.__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (.core.__CALL_BACK__), hl
+	ei
+	jp .core.__MAIN_PROGRAM__
+.core.__CALL_BACK__:
+	DEFW 0
+.core.ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+.core.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_END - .core.ZXBASIC_USER_DATA
+	.core.__LABEL__.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_LEN
+	.core.__LABEL__.ZXBASIC_USER_DATA EQU .core.ZXBASIC_USER_DATA
+.core.ZXBASIC_USER_DATA_END:
+.core.__MAIN_PROGRAM__:
+	call _distance
+	ld hl, 0
+	ld b, h
+	ld c, l
+.core.__END_PROGRAM:
+	di
+	ld hl, (.core.__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	exx
+	pop iy
+	pop ix
+	ei
+	ret
+_distance:
+	push ix
+	ld ix, 0
+	add ix, sp
+	ld a, 1
+	jp _distance__leave
+.LABEL._mylabel:
+_distance__leave:
+	ld sp, ix
+	pop ix
+	ret
+	;; --- end of user code ---
+	END

--- a/tests/functional/arch/zx48k/warn_lbl.bas
+++ b/tests/functional/arch/zx48k/warn_lbl.bas
@@ -1,0 +1,10 @@
+REM Should not emit a warning (unreachable code) 
+REM ... due to label in line 4
+
+FUNCTION distance () as uByte
+  return 1
+mylabel:
+END FUNCTION
+
+distance
+

--- a/tests/functional/cmdline/test_warning.txt
+++ b/tests/functional/cmdline/test_warning.txt
@@ -10,3 +10,5 @@ doloop2.bas:4: warning: [W100] Using default implicit type 'ubyte' for 'a'
 doloop2.bas:4: warning: [W150] Variable 'a' is never used
 
 >>> process_file('arch/zx48k/warn_brk.bas', ['-S', '-q', '-O --enable-break'])
+
+>>> process_file('arch/zx48k/warn_lbl.bas', ['-S', '-q'])


### PR DESCRIPTION
When using a label before of a RETURN
sentence within a function, a warning
was emitted. Fixed.

Fixes #822 
