### PR TITLE
doc: fixes using unescaped < > in Markdown

### DIFF
--- a/docs/lbound.md
+++ b/docs/lbound.md
@@ -10,12 +10,12 @@ LBound(<array variable>, <dimension>)
 
 ## Description
 
-Returns the array lower bound of the given <dimension>. If the <dimension> is not specified, it defaults to 0.
-If the specified <dimension> is 0, then total number of dimensions is returned.
+Returns the array lower bound of the given `dimension`. If `dimension` is not specified, it defaults to 0.
+If the given `dimension` is 0, then total number of dimensions is returned.
 
 ## Examples
 
-```
+```basic
 DIM a(3 TO 5, 1 TO 8)
 PRINT LBound(a, 2) : REM Prints 1
 PRINT Lbound(a) : REM Prints 2, the number of dimensions
@@ -27,7 +27,7 @@ The result is always a 16bit integer value.
 If `<dimension>` is 0 the number of dimensions in the array is returned
 (use it to guess the number of dimensions of an array):
 
-```
+```basic
 DIM a(3 TO 5, 2 TO 8)
 PRINT LBound(a, 0): REM Prints 2, since 'a' has 2 dimensions
 ```

--- a/docs/ubound.md
+++ b/docs/ubound.md
@@ -9,12 +9,12 @@ UBound(<array variable>, <dimension>)
 
 ## Description
 
-Returns the array upper bound of the given <dimension>. If the <dimension> is not specified, it defaults to 0.
-If the specified <dimension> is 0, then total number of dimensions is returned.
+Returns the array upper bound of the given `dimension`. If `dimension` is not specified, it defaults to 0.
+If the given `dimension` is 0, then total number of dimensions is returned.
 
 ## Examples
 
-```
+```basic
 DIM a(3 TO 5, 2 TO 8)
 PRINT UBound(a, 2) : REM Prints 8
 PRINT Ubound(a) : REM Prints 2, because it has 2 dimensions
@@ -26,7 +26,7 @@ The result is always a 16bit integer value.
 If `<dimension>` is 0 the number of dimensions in the array is returned
 (use it to guess the number of dimensions of an array):
 
-```
+```basic
 DIM a(3 TO 5, 2 TO 8)
 PRINT UBound(a, 0): REM Prints 2, since 'a' has 2 dimensions
 ```


### PR DESCRIPTION
Fixes #872