### PR TITLE
fix: wrong filename in errors

### DIFF
--- a/src/api/global_.py
+++ b/src/api/global_.py
@@ -14,6 +14,7 @@ from src.api.constants import TYPE, LoopType
 from src.api.opcodestemps import OpcodesTemps
 
 if TYPE_CHECKING:
+    from src.symbols.call import SymbolCALL
     from src.symbols.id_ import SymbolID
 
 
@@ -90,7 +91,7 @@ SYMBOL_TABLE = None  # Must be initialized with SymbolTable instance
 # Function calls pending to check
 # Each scope pushes (prepends) an empty list
 # ----------------------------------------------------------------------
-FUNCTION_CALLS: list[SymbolID] = []
+FUNCTION_CALLS: list[SymbolCALL] = []
 
 # ----------------------------------------------------------------------
 # Function level entry ID in which scope we are in. If the list

--- a/src/symbols/call.py
+++ b/src/symbols/call.py
@@ -95,17 +95,13 @@ class SymbolCALL(Symbol):
                 return None
 
         if entry.declared and not entry.forwarded:
-            check.check_call_arguments(lineno, id_, params)
+            check.check_call_arguments(lineno, id_, params, filename)
         else:  # All functions goes to global scope by default
             if entry.token != "FUNCTION":
                 entry = entry.to_function(lineno)
             gl.SYMBOL_TABLE.move_to_global_scope(id_)
-            gl.FUNCTION_CALLS.append(
-                (
-                    id_,
-                    params,
-                    lineno,
-                )
-            )
+            result = cls(entry, params, lineno, filename)
+            gl.FUNCTION_CALLS.append(result)
+            return result
 
         return cls(entry, params, lineno, filename)

--- a/src/symbols/call.py
+++ b/src/symbols/call.py
@@ -40,8 +40,8 @@ class SymbolCALL(Symbol):
         super().__init__()
         self.entry = entry
         self.args = arglist  # Func. call / array access
-        self.lineno = lineno
-        self.filename = filename
+        self.lineno: int = lineno
+        self.filename: str = filename
 
         ref = entry.ref
         if isinstance(ref, FuncRef):

--- a/src/symbols/id_/_id.py
+++ b/src/symbols/id_/_id.py
@@ -33,6 +33,7 @@ class SymbolID(SymbolIdABC):
 
     __slots__ = (
         "name",
+        "original_name",
         "filename",
         "lineno",
         "mangled",
@@ -58,7 +59,8 @@ class SymbolID(SymbolIdABC):
         super().__init__(name=name, lineno=lineno, filename=filename, type_=type_, class_=class_)
         assert class_ in (CLASS.const, CLASS.label, CLASS.var, CLASS.unknown)
 
-        self.name = name
+        self.name = name  # This value will be modified later removing the trailing sigil ($) if used.
+        self.original_name = name  # This value will always contain the original name, preserving the sigil if used
         self.filename = global_.FILENAME if filename is None else filename  # In which file was first used
         self.lineno = lineno  # In which line was first used
         self.mangled = f"{global_.MANGLE_CHR}{name}"  # This value will be overridden later

--- a/tests/functional/arch/zx48k/bad_fname_err5.bas
+++ b/tests/functional/arch/zx48k/bad_fname_err5.bas
@@ -1,0 +1,10 @@
+#line 1 "file2.bas"
+#line 1 "file1.bas"
+sub foo(a as ubyte, b as ubyte)
+    print a, ", ", b
+end sub
+
+#line 2 "file2.bas"
+
+
+foo(42)

--- a/tests/functional/arch/zx48k/bad_fname_err6.bas
+++ b/tests/functional/arch/zx48k/bad_fname_err6.bas
@@ -1,0 +1,10 @@
+#line 1 "file2.bas"
+#line 1 "file1.bas"
+sub foo(a as ubyte, b as ubyte)
+    print a, ", ", b
+end sub
+
+#line 2 "file2.bas"
+
+
+foo(42, 43, 44)

--- a/tests/functional/cmdline/test_errmsg.txt
+++ b/tests/functional/cmdline/test_errmsg.txt
@@ -159,6 +159,10 @@ ND.Controls.bas:4: error: Invalid argument 'dirData'
 ND.Controls.bas:2: warning: [W150] Variable 'dirData' is never used
 >>> process_file('arch/zx48k/bad_fname_err4.bas', ['-S', '-q'])
 ND.Controls.bas:2: error: sub 'Controls_LABEL' declared but not implemented
+>>> process_file('arch/zx48k/bad_fname_err5.bas', ['-S', '-q'])
+file2.bas:4: error: Function 'foo' takes 2 parameters, not 1
+>>> process_file('arch/zx48k/bad_fname_err6.bas', ['-S', '-q'])
+file2.bas:4: error: Too many arguments for Function 'foo'
 
 # DO LOOP type errors
 >>> process_file('arch/zx48k/do_crash.bas', ['-S', '-q'])


### PR DESCRIPTION
Sometimes, when including a file and having an error on a function call, the error shows the filename where the function was defined, not where the error actually happened.