### PR TITLE
Sustituye "ld (xxxx), sp"

### DIFF
--- a/src/arch/z80/backend/main.py
+++ b/src/arch/z80/backend/main.py
@@ -661,9 +661,7 @@ class Backend(BackendInterface):
         output.append("exx")
         output.append("push hl")
         output.append("exx")
-        output.append("ld hl, 0")
-        output.append("add hl, sp")
-        output.append(f"ld ({common.CALL_BACK}), hl")
+        output.append(f"ld ({common.CALL_BACK}), sp")
         output.append("ei")
 
         output.extend(f"call {x}" for x in sorted(common.INITS))

--- a/src/arch/zxnext/backend/main.py
+++ b/src/arch/zxnext/backend/main.py
@@ -75,9 +75,7 @@ class Backend(Z80Backend):
         output.append("di")
         output.append("push iy")
         output.append("ld iy, 0x5C3A  ; ZX Spectrum ROM variables address")
-        output.append("ld hl, 0")
-        output.append("add hl, sp")
-        output.append(f"ld ({common.CALL_BACK}), hl")
+        output.append(f"ld ({common.CALL_BACK}), sp")
         output.append("ei")
 
         output.extend(f"call {x}" for x in sorted(common.INITS))

--- a/src/lib/arch/zx48k/runtime/arith/divf.asm
+++ b/src/lib/arch/zx48k/runtime/arith/divf.asm
@@ -27,9 +27,7 @@ ERR_SP      EQU 23613
     ld (TMP), hl
     ld hl, __DIVBYZERO
     push hl
-    ld hl, 0
-    add hl, sp
-    ld (ERR_SP), hl
+    ld (ERR_SP), sp
 
     ; ------------- ROM DIV
     rst 28h

--- a/src/lib/arch/zx48k/runtime/val.asm
+++ b/src/lib/arch/zx48k/runtime/val.asm
@@ -59,9 +59,7 @@ SET_MIN     EQU 16B0h
     ;; Now put our error handler on ERR_SP
     ld hl, __VAL_ERROR
     push hl
-    ld hl, 0
-    add hl, sp
-    ld (ERR_SP), hl
+    ld (ERR_SP), sp
 
     call STK_STO_S ; Enter it on the stack
 

--- a/src/lib/arch/zxnext/runtime/arith/divf.asm
+++ b/src/lib/arch/zxnext/runtime/arith/divf.asm
@@ -27,9 +27,7 @@ ERR_SP      EQU 23613
     ld (TMP), hl
     ld hl, __DIVBYZERO
     push hl
-    ld hl, 0
-    add hl, sp
-    ld (ERR_SP), hl
+    ld (ERR_SP), sp
 
     ; ------------- ROM DIV
     rst 28h

--- a/src/lib/arch/zxnext/runtime/val.asm
+++ b/src/lib/arch/zxnext/runtime/val.asm
@@ -59,9 +59,7 @@ SET_MIN     EQU 16B0h
     ;; Now put our error handler on ERR_SP
     ld hl, __VAL_ERROR
     push hl
-    ld hl, 0
-    add hl, sp
-    ld (ERR_SP), hl
+    ld (ERR_SP), sp
 
     call STK_STO_S ; Enter it on the stack
 


### PR DESCRIPTION
Sustituye `ld (xxxx), sp`  en vez de  `ld hl, 0; add hl, sp; ld (xxxx), hl`.