### PR TITLE
Fixes @array label emission

### DIFF
--- a/src/api/optimize.py
+++ b/src/api/optimize.py
@@ -58,7 +58,7 @@ class GenericVisitor(NodeVisitor):
         if node.obj is None:
             return None
 
-        __DEBUG__(f"Optimizer: Visiting node {node.obj!s}", 1)
+        __DEBUG__(f"Optimizer: Visiting node {node.obj!s}[{node.obj.token}]", 1)
         meth = getattr(self, f"visit_{node.obj.token}", self.generic_visit)
         return meth(node.obj)
 

--- a/src/arch/z80/visitor/translator_visitor.py
+++ b/src/arch/z80/visitor/translator_visitor.py
@@ -225,9 +225,6 @@ class TranslatorVisitor(TranslatorInstVisitor):
             syntax_error_cant_convert_to_type(node.lineno, str(node.operand), node.type_)
             return None
 
-        if node.token == "VARARRAY":
-            return node.data_label
-
         if node.token in ("CONST", "VAR", "LABEL", "FUNCTION"):
             # TODO: Check what happens with local vars and params
             return node.t
@@ -238,7 +235,7 @@ class TranslatorVisitor(TranslatorInstVisitor):
         if node.token == "ARRAYACCESS":
             return f"({node.entry.data_label} + {node.offset})"
 
-        if node.token == "ID" and node.has_address and node.scope == SCOPE.global_:
+        if node.token in ("ID", "VARARRAY") and node.has_address and node.scope == SCOPE.global_:
             return node.mangled
 
         raise InvalidCONSTexpr(node)

--- a/tests/functional/arch/zx48k/arrlabels1.asm
+++ b/tests/functional/arch/zx48k/arrlabels1.asm
@@ -23,9 +23,9 @@ _a.__DATA__.__PTR__:
 	DEFW 0
 	DEFW 0
 _a.__DATA__:
-	DEFW _a.__DATA__
-	DEFW _a.__DATA__
-	DEFW (_a.__DATA__) + (1)
+	DEFW _a
+	DEFW _a
+	DEFW (_a) + (1)
 .LABEL.__LABEL0:
 	DEFW 0000h
 	DEFB 02h

--- a/tests/functional/arch/zx48k/arrlabels10a.asm
+++ b/tests/functional/arch/zx48k/arrlabels10a.asm
@@ -23,8 +23,8 @@ _a.__DATA__.__PTR__:
 	DEFW 0
 	DEFW 0
 _a.__DATA__:
-	DEFB (_a.__DATA__) & 0xFF
-	DEFB ((_a.__DATA__) + (1)) & 0xFF
+	DEFB (_a) & 0xFF
+	DEFB ((_a) + (1)) & 0xFF
 	DEFB 04h
 .LABEL.__LABEL0:
 	DEFW 0000h

--- a/tests/functional/arch/zx48k/arrlabels10b.asm
+++ b/tests/functional/arch/zx48k/arrlabels10b.asm
@@ -24,9 +24,9 @@ _a.__DATA__.__PTR__:
 	DEFW 0
 _a.__DATA__:
 	DEFW 0000h
-	DEFW (_a.__DATA__) & 0xFFFF
+	DEFW (_a) & 0xFFFF
 	DEFW 0000h
-	DEFW ((_a.__DATA__) + (1)) & 0xFFFF
+	DEFW ((_a) + (1)) & 0xFFFF
 	DEFB 00h
 	DEFB 00h
 	DEFB 04h

--- a/tests/functional/arch/zx48k/arrlabels2.asm
+++ b/tests/functional/arch/zx48k/arrlabels2.asm
@@ -23,9 +23,9 @@ _a.__DATA__.__PTR__:
 	DEFW _a.__LBOUND__
 	DEFW 0
 _a.__DATA__:
-	DEFW _a.__DATA__
-	DEFW _a.__DATA__
-	DEFW (_a.__DATA__) + (1)
+	DEFW _a
+	DEFW _a
+	DEFW (_a) + (1)
 .LABEL.__LABEL0:
 	DEFW 0000h
 	DEFB 02h

--- a/tests/functional/arch/zx48k/arrlabels3.asm
+++ b/tests/functional/arch/zx48k/arrlabels3.asm
@@ -23,9 +23,9 @@ _a.__DATA__.__PTR__:
 	DEFW _a.__LBOUND__
 	DEFW 0
 _a.__DATA__:
-	DEFW _a.__DATA__
-	DEFW _a.__DATA__
-	DEFW (_a.__DATA__) + (_f)
+	DEFW _a
+	DEFW _a
+	DEFW (_a) + (_f)
 .LABEL.__LABEL0:
 	DEFW 0000h
 	DEFB 02h

--- a/tests/functional/arch/zx48k/opt1_dim_arr_at1.asm
+++ b/tests/functional/arch/zx48k/opt1_dim_arr_at1.asm
@@ -72,9 +72,9 @@ _b.__DATA__:
 	DEFB 02h
 .core.ZXBASIC_USER_DATA_END:
 .core.__MAIN_PROGRAM__:
-	ld hl, _a.__DATA__
+	ld hl, _a
 	ld (_c), hl
-	ld hl, _b.__DATA__
+	ld hl, _b
 	ld (_c), hl
 	ld hl, 0
 	ld b, h


### PR DESCRIPTION
## What / Why

Fixes `@myvar` when `myvar` is a global array.
Also improves visitor traversing debug info.