### PR TITLE
fix: implement ByRef with an Array Element

### DIFF
--- a/src/api/check.py
+++ b/src/api/check.py
@@ -160,13 +160,13 @@ def check_call_arguments(lineno: int, id_: str, args, filename: str):
             return False
 
         if param.byref:
-            if not isinstance(arg.value, symbols.ID):
+            if not isinstance(arg.value, (symbols.ID, symbols.ARRAYLOAD)):
                 errmsg.error(
                     lineno, "Expected a variable name, not an expression (parameter By Reference)", fname=arg.filename
                 )
                 return False
 
-            if arg.class_ not in (CLASS.var, CLASS.array):
+            if arg.class_ not in (CLASS.var, CLASS.array, CLASS.unknown):
                 errmsg.error(lineno, "Expected a variable or array name (parameter By Reference)")
                 return False
 

--- a/src/arch/z80/visitor/translator.py
+++ b/src/arch/z80/visitor/translator.py
@@ -1,6 +1,5 @@
-from collections import namedtuple
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NamedTuple
 
 import src.api.errmsg
 import src.api.global_ as gl
@@ -22,6 +21,7 @@ from src.arch.z80.visitor.builtin_translator import BuiltinTranslator
 from src.arch.z80.visitor.translator_visitor import JumpTable, TranslatorVisitor
 from src.arch.z80.visitor.unary_op_translator import UnaryOpTranslator
 from src.symbols import sym as symbols
+from src.symbols.arrayaccess import SymbolARRAYACCESS
 from src.symbols.id_ import ref
 from src.symbols.type_ import Type
 
@@ -30,7 +30,10 @@ __all__ = (
     "Translator",
 )
 
-LabelledData = namedtuple("LabelledData", ("label", "data"))
+
+class LabelledData(NamedTuple):
+    label: str
+    data: list[str]
 
 
 class Translator(TranslatorVisitor):
@@ -210,7 +213,10 @@ class Translator(TranslatorVisitor):
             else:
                 yield node.value
             self.ic_param(node.type_, node.t)
-        else:
+            return
+
+        # ByRef argument
+        if node.value.token != "ARRAYLOAD":
             scope = node.value.scope
             if node.t[0] == "_":
                 t = optemps.new_t()
@@ -229,6 +235,12 @@ class Translator(TranslatorVisitor):
                 self.ic_paddr(-node.value.offset, t)
 
             self.ic_param(TYPE.uinteger, t)
+            return
+
+        # Must compute Address of @array(...)
+        node.value = SymbolARRAYACCESS.copy_from(node.value)
+        node.value = symbols.UNARY("ADDRESS", node.value, node.lineno, type_=self.TYPE(gl.PTR_TYPE))
+        yield node.value
 
     def visit_ARRAYLOAD(self, node):
         scope = node.entry.scope

--- a/src/arch/z80/visitor/translator_inst_visitor.py
+++ b/src/arch/z80/visitor/translator_inst_visitor.py
@@ -195,7 +195,7 @@ class TranslatorInstVisitor(NodeVisitor):
     def ic_paddr(self, t1, t2) -> None:
         self.emit("paddr", t1, t2)
 
-    def ic_paload(self, type_: TYPE | sym.BASICTYPE, t, offset: int) -> None:
+    def ic_paload(self, type_: TYPE | sym.BASICTYPE, t, offset: str) -> None:
         self.emit(f"paload{self.TSUFFIX(type_)}", t, offset)
 
     def ic_param(self, type_: TYPE | sym.BASICTYPE, t) -> None:

--- a/src/symbols/argument.py
+++ b/src/symbols/argument.py
@@ -63,7 +63,7 @@ class SymbolARGUMENT(Symbol):
     @byref.setter
     def byref(self, value):
         if value:
-            assert self.value.token in ("VAR", "VARARRAY")
+            assert self.value.token in ("VAR", "VARARRAY", "ARRAYLOAD")
         self._byref = value
 
     @property

--- a/src/symbols/arrayaccess.py
+++ b/src/symbols/arrayaccess.py
@@ -1,6 +1,12 @@
-# vim: ts=4:et:sw=4:
+# ----------------------------------------------------------------------
+# Copyleft (K), Jose M. Rodriguez-Rosa (a.k.a. Boriel)
+#
+# This program is Free Software and is released under the terms of
+#                    the GNU General License
+# ----------------------------------------------------------------------
+
 from functools import cached_property
-from typing import Optional
+from typing import Self
 
 import src.api.global_ as gl
 from src.api import check, errmsg
@@ -9,13 +15,6 @@ from src.symbols.arglist import SymbolARGLIST
 from src.symbols.call import SymbolCALL
 from src.symbols.id_ import SymbolID
 from src.symbols.typecast import SymbolTYPECAST as TYPECAST
-
-# ----------------------------------------------------------------------
-# Copyleft (K), Jose M. Rodriguez-Rosa (a.k.a. Boriel)
-#
-# This program is Free Software and is released under the terms of
-#                    the GNU General License
-# ----------------------------------------------------------------------
 
 
 class SymbolARRAYACCESS(SymbolCALL):
@@ -38,7 +37,7 @@ class SymbolARRAYACCESS(SymbolCALL):
         self.entry.ref.is_dynamically_accessed = True
 
     @property
-    def entry(self):
+    def entry(self) -> SymbolID:
         return self.children[0]
 
     @entry.setter
@@ -54,7 +53,7 @@ class SymbolARRAYACCESS(SymbolCALL):
         return self.entry.type_
 
     @property
-    def arglist(self):
+    def arglist(self) -> SymbolARGLIST:
         return self.children[1]
 
     @arglist.setter
@@ -98,7 +97,7 @@ class SymbolARRAYACCESS(SymbolCALL):
         return self.offset is None
 
     @classmethod
-    def make_node(cls, id_: str, arglist: SymbolARGLIST, lineno: int, filename: str) -> Optional["SymbolARRAYACCESS"]:
+    def make_node(cls, id_: str, arglist: SymbolARGLIST, lineno: int, filename: str) -> Self | None:
         """Creates an array access. A(x1, x2, ..., xn)"""
         assert isinstance(arglist, SymbolARGLIST)
         variable = gl.SYMBOL_TABLE.access_array(id_, lineno)
@@ -129,3 +128,7 @@ class SymbolARRAYACCESS(SymbolCALL):
 
         # Returns the variable entry and the node
         return cls(variable, arglist, lineno, filename)
+
+    @classmethod
+    def copy_from(cls, other: Self) -> Self | None:
+        return cls(entry=other.entry, arglist=other.arglist, lineno=other.lineno, filename=other.filename)

--- a/src/symbols/arrayload.py
+++ b/src/symbols/arrayload.py
@@ -12,7 +12,8 @@ from src.symbols.arrayaccess import SymbolARRAYACCESS
 
 class SymbolARRAYLOAD(SymbolARRAYACCESS):
     """This class is the same as SymbolARRAYACCESS, we just declare it to make
-    a distinction. (e.g. the Token is gotten from the class name)
+    a distinction. (e.g. the Token is gotten from the class name).
+
     """
 
     pass


### PR DESCRIPTION
## What / Why

Now it's possible to do:

```basic
DIM a(2) As Ubyte

SUB Incr(ByRef x As Ubyte)
  LET x = x + 1
END SUB

Incr(a(2))
```
So it's possible to pass single array elements as `ByRef` params whose value can be changed.
